### PR TITLE
chore: exit successfully depcheck if no missing deps

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Dependency check
-        run: pnpm run depcheck
+        run: pnpm run depcheck | grep -q "Missing" && exit 1 || exit 0


### PR DESCRIPTION
Ignore unused dependencies.
`depcheck` cli doesn't allow to disable checking unused deps
