### PR TITLE
chore: exit successfully depcheck if no missing deps

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,4 +42,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Dependency check
-        run: pnpm run depcheck
+        run: |
+          pnpm run depcheck | tee depcheck.txt
+          cat depcheck.txt | grep -q "Missing dependencies" && exit 1 || exit 0

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -43,5 +43,5 @@ jobs:
 
       - name: Dependency check
         run: |
-          pnpm run depcheck | tee depcheck.txt
+          pnpm run depcheck | sed '$d' | tee depcheck.txt
           cat depcheck.txt | grep -q "Missing dependencies" && exit 1 || exit 0


### PR DESCRIPTION
Ignore unused dependencies.
`depcheck` cli doesn't allow to disable checking unused deps
